### PR TITLE
Update version of wavefront-dropwizard-metrics-sdk-java to 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-dropwizard-metrics-sdk-java</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-dropwizard-sdk-java</artifactId>
-    <version>0.9.6-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Wavefront by VMware Dropwizard SDK for Java</name>


### PR DESCRIPTION
wavefront-dropwizard-metrics-sdk-java has a newer version.  Let's use the latest!