### PR TITLE
Revert failed release commits

### DIFF
--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -1,6 +1,6 @@
 open_source_licenses.txt
 
-Wavefront by VMware Dropwizard SDK for Java 1.2.2 GA
+Wavefront by VMware Dropwizard SDK for Java 1.2.0 GA
 
 ======================================================================
 
@@ -561,4 +561,4 @@ Source Files is valid for three years from the date you acquired or last used th
 Software product. Alternatively, the Source Files may accompany the
 VMware service.
 
-[WAVEFRONTDROPWIZARDSDKJAVA122GAAB041720]
+[WAVEFRONTDROPWIZARDSDKJAVA120GAAB041720]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-dropwizard-sdk-java</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Wavefront by VMware Dropwizard SDK for Java</name>


### PR DESCRIPTION
This revert commits:
2d9a729 [maven-release-plugin] prepare for next development iteration
a0ad923 [maven-release-plugin] prepare release v1.2.2
aad69b3 update open_source_licenses.txt for release (v1.2.2)
455fff1 [maven-release-plugin] prepare for next development iteration
2ab9323 [maven-release-plugin] prepare release v1.2.1
6d00100 update open_source_licenses.txt for release (v1.2.1)

failed due to nexus-staging timeout issues